### PR TITLE
ci: fix tests locally and in pipline

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -17,6 +17,8 @@ services:
     env_file: .env
     depends_on:
       - postgres
+    restart: always
+    
 
   api:
     container_name: maxitwitapi
@@ -35,6 +37,7 @@ services:
     env_file: .env
     depends_on:
       - postgres
+    restart: always
 
   prometheus:
     image: prom/prometheus

--- a/tests/maxitwit_test.py
+++ b/tests/maxitwit_test.py
@@ -103,8 +103,8 @@ def setup(request):
     if request.config.getoption("--container"):
         global APP_URL
         global API_URL
-        APP_URL = "http://maxitwitserver"
-        API_URL = "http://maxitwitapi"
+        APP_URL = "http://test_server"
+        API_URL = "http://test_api"
 
 
 # ---- API TESTS ----

--- a/tests_compose.yaml
+++ b/tests_compose.yaml
@@ -1,5 +1,5 @@
 services:
-  postgres:
+  test_db:
     image: postgres:latest
     environment:
       POSTGRES_USER: postgres
@@ -10,8 +10,8 @@ services:
     networks:
       - main
 
-  maxitwitserver:
-    container_name: maxitwitserver
+  test_server:
+    container_name: test_server
     build:
       dockerfile: Dockerfile.app
       context: .
@@ -21,14 +21,15 @@ services:
     networks:
       - main
     depends_on:
-      - postgres
+      - test_db
     environment:
       - HUSKY=0
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/testdb
+      - DATABASE_URL=postgresql://postgres:postgres@test_db:5432/testdb
       - SESSION_SECRET=secret
+    restart: always
 
-  maxitwitapi:
-    container_name: maxitwitapi
+  test_api:
+    container_name: test_api
     build:
       dockerfile: Dockerfile.api
       context: .
@@ -38,11 +39,12 @@ services:
     networks:
       - main
     depends_on:
-      - postgres
+      - test_db
     environment:
       - HUSKY=0
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/testdb
+      - DATABASE_URL=postgresql://postgres:postgres@test_db:5432/testdb
       - SESSION_SECRET=secret
+    restart: always
 
 networks:
   main:


### PR DESCRIPTION
Added autorestart to test-compose, also added to local compose, so server, api containers restart until the postgres container  boots up properly

fix #68